### PR TITLE
补充实战踩坑经验：渲染队列、CORS、持久化、退出机制、设计令牌

### DIFF
--- a/skills/build-and-deploy/SKILL.md
+++ b/skills/build-and-deploy/SKILL.md
@@ -167,6 +167,50 @@ npx evenhub pack <app.json> <build-folder> [options]
 
 ---
 
+## CORS in the WebView — Day-1 Blocker
+
+The Even App WebView is a real browser engine (Chromium on Android, WKWebView on iOS). **Full CORS enforcement applies.** The `app.json` network whitelist is an Even-level permission layer — it does NOT bypass CORS. You need BOTH:
+
+1. Domain whitelisted in `app.json` `permissions.network.whitelist`
+2. The remote server returning `Access-Control-Allow-Origin` headers
+
+If the API you're calling doesn't send CORS headers, your `fetch()` will fail with a network error — even though the domain is whitelisted.
+
+### Solutions
+
+| Scenario | Fix |
+|----------|-----|
+| API returns `Access-Control-Allow-Origin: *` | Just `fetch()` directly. It works. |
+| API has no CORS headers | Use a Cloudflare Worker proxy (free tier), your own backend, or find a CORS-enabled mirror |
+| You control the API | Add `Access-Control-Allow-Origin: *` to your server responses |
+
+### During development (Vite dev server)
+
+Use a Vite proxy to avoid CORS during local development:
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  server: {
+    host: true,
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'https://api.example.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+})
+```
+
+This proxy only works in dev. For production `.ehpk`, the WebView makes requests directly — your API must have CORS headers or you must route through a proxy.
+
+### Common mistake: free CORS proxy services
+
+Free proxies like `corsproxy.io`, `allorigins.win`, and `api.codetabs.com` are unreliable — they go down, return 403s, or timeout without warning. If your app depends on a third-party API without CORS, deploy your own Cloudflare Worker (free, 5 minutes) or find a mirror that has CORS headers natively.
+
 ## Distribution
 
 Once the `.ehpk` file is verified, submit it to the **Even Hub developer portal** for review and publication. The portal will validate the package, run compatibility checks, and make the app available to Even Hub G2 users after approval.

--- a/skills/design-guidelines/SKILL.md
+++ b/skills/design-guidelines/SKILL.md
@@ -77,6 +77,65 @@ Full supported glyph tables: https://github.com/nickustinov/even-g2-notes
 Official design guidelines covering layout principles, component patterns, interaction models, and visual standards:
 https://www.figma.com/design/X82y5uJvqMH95jgOfmV34j/Even-Realities---Software-Design-Guidelines--Public-?node-id=2922-80782
 
+## App-Side Design Tokens (WebView Settings UI)
+
+When the app has a phone-side settings or configuration screen, use these design tokens for visual consistency with the Even brand. These values come from Design Library 3.0 and even-toolkit.
+
+### Colors
+
+| Token | Light | Dark | Usage |
+|-------|-------|------|-------|
+| `--color-text` | #232323 | #F0EBE3 | Primary text |
+| `--color-text-dim` | #7B7B7B | #8A7F72 | Secondary text |
+| `--color-text-muted` | #A7A7A7 | #5C5347 | Tertiary/disabled |
+| `--color-bg` | #EEEEEE | #0C0A07 | Page background |
+| `--color-surface` | #FFFFFF | #161310 | Card surface |
+| `--color-surface-alt` | #F6F6F6 | #201C17 | Elevated surface |
+| `--color-border` | #E4E4E4 | #28221A | Default border |
+| `--color-accent` | #232323 | #FFFFFF | Primary CTA |
+| `--color-accent-warning` | #FEF991 | #FEF991 | Brand Yellow — accent only, sparingly |
+| `--color-positive` | #4BB956 | — | Success |
+| `--color-negative` | #FF453A | — | Error |
+
+- **#FEF991 (Brand Yellow)** = accent only. Never for body text.
+- **#3CFA44 (OS Green)** = glasses display ONLY. Never in app UI.
+- Dark mode uses warm-tinted neutrals, not neutral gray.
+
+### Typography
+
+| Style | Size | Weight | Letter Spacing |
+|-------|------|--------|----------------|
+| Very Large Title | 24px | 400 | -0.72px |
+| Large Title | 20px | 400 | -0.60px |
+| Medium Title | 17px | 400 | -0.17px |
+| Medium Body | 17px | 300 | -0.17px |
+| Normal Title | 15px | 400 | -0.15px |
+| Normal Body | 15px | 300 | -0.15px |
+| Subtitle | 13px | 400 | -0.13px |
+| Detail | 11px | 400 | -0.11px |
+
+- **Font**: FK Grotesk Neue. Fallback: -apple-system, sans-serif.
+- Weight 400 for titles, 300 for body. Never use bold (700).
+- Negative letter spacing is a brand signature — do not override.
+- Minimum font size: 11px.
+
+### Spacing
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--spacing-same` | 6px | Related items |
+| `--spacing-margin` | 12px | Standard margin |
+| `--spacing-card-margin` | 16px | Card padding |
+| `--spacing-section` | 24px | Between sections |
+| `--radius-default` | 6px | All cards/inputs/buttons |
+
+### Rules
+
+- Support BOTH light and dark themes (use `prefers-color-scheme` media query)
+- Use even-toolkit components when available — do not roll custom equivalents
+- Use CSS variables, not hardcoded pixel values
+- No Tailwind CSS — plain CSS or CSS variables only
+
 ## Community Resources
 
 - **even-g2-notes** (GitHub: https://github.com/nickustinov/even-g2-notes) — architecture deep-dives, full Unicode glyph tables, SDK quirks, error codes, reference implementations: chess, reddit reader, weather, Tesla vehicle status, pong, snake

--- a/skills/device-features/SKILL.md
+++ b/skills/device-features/SKILL.md
@@ -119,6 +119,45 @@ Persist data to the Even Realities App (survives app restarts):
 - `await bridge.setLocalStorage(key, value)` — stores a string value; returns `boolean` indicating success
 - `await bridge.getLocalStorage(key)` — retrieves a stored string; returns an empty string if the key does not exist
 
+### SDK localStorage is the ONLY reliable persistence
+
+The Even App WebView is a Flutter WebView. **Browser IndexedDB and browser localStorage do NOT persist across app restarts** in this environment. Data stored there will be lost when the user closes and reopens the app.
+
+Use `bridge.setLocalStorage` / `bridge.getLocalStorage` for ALL user state: settings, progress, bookmarks, preferences, cached data. For large content (e.g., ebook text), chunk it into multiple keys:
+
+```typescript
+const CHUNK_SIZE = 50_000  // chars per key
+const PREFIX = 'myapp.content_'
+
+async function saveContent(bridge: EvenAppBridge, id: string, text: string) {
+  const chunks = Math.ceil(text.length / CHUNK_SIZE)
+  await bridge.setLocalStorage(`${PREFIX}${id}_n`, String(chunks))
+  for (let i = 0; i < chunks; i++) {
+    await bridge.setLocalStorage(`${PREFIX}${id}_${i}`, text.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE))
+  }
+}
+```
+
+### Debounced persistence
+
+Calling `bridge.setLocalStorage` on every state change (e.g., every page turn) spams the bridge. Debounce writes and flush immediately on exit:
+
+```typescript
+let saveTimeout: number | null = null
+
+function saveState() {
+  if (saveTimeout) clearTimeout(saveTimeout)
+  saveTimeout = window.setTimeout(flushState, 500)
+}
+
+async function flushState() {
+  if (saveTimeout) { clearTimeout(saveTimeout); saveTimeout = null }
+  await bridge.setLocalStorage('myapp.state', JSON.stringify(state))
+}
+
+// Call flushState() on FOREGROUND_EXIT, ABNORMAL_EXIT, SYSTEM_EXIT, and before shutDownPageContainer
+```
+
 ---
 
 ## Cleanup on Exit

--- a/skills/glasses-ui/SKILL.md
+++ b/skills/glasses-ui/SKILL.md
@@ -228,6 +228,92 @@ shutDownPageContainer(type: number): Promise<boolean>
 - **Do not call `updateImageRawData` concurrently** — queue updates and await each before sending the next
 - **Pre-paginate long text** at ~400–500 character boundaries and use `rebuildPageContainer` on scroll events
 
+## Render Queue — Prevent Concurrent Bridge Calls
+
+Bridge calls go over BLE to the glasses. Sending multiple calls concurrently crashes the glasses or causes undefined behavior. **Serialize all bridge render calls through a queue.**
+
+Additionally, a single BLE call can hang for ~30 seconds if the connection is flaky. Without a timeout, this blocks the entire render pipeline. Use `Promise.race` to cap each call.
+
+```typescript
+let renderInFlight = false
+let pendingRender: (() => Promise<void>) | null = null
+const RENDER_TIMEOUT_MS = 4000
+
+async function enqueueRender(fn: () => Promise<void>) {
+  if (renderInFlight) {
+    pendingRender = fn  // only keep latest — drop intermediate
+    return
+  }
+  renderInFlight = true
+  try {
+    await Promise.race([
+      fn(),
+      new Promise<void>((_, rej) =>
+        setTimeout(() => rej(new Error('render timeout')), RENDER_TIMEOUT_MS)
+      ),
+    ])
+  } catch {
+    // Timeout or bridge error — drop it, next call will retry
+  } finally {
+    renderInFlight = false
+    if (pendingRender) {
+      const next = pendingRender
+      pendingRender = null
+      await enqueueRender(next)
+    }
+  }
+}
+```
+
+## Startup Page Tracking — Critical
+
+`createStartUpPageContainer` must be called **exactly once**. All subsequent page changes must use `rebuildPageContainer`. Calling `createStartUpPageContainer` repeatedly floods the bridge and crashes the glasses.
+
+**Warning:** Do NOT check the return value to decide whether startup succeeded. The SDK documentation says it returns `0` on success, but in practice it may return the string `'success'`. Gating on `result === 0` silently fails, causing every render to re-call `createStartUpPageContainer`.
+
+```typescript
+let startupRendered = false
+
+async function renderPage(bridge: EvenAppBridge, config: any) {
+  await enqueueRender(async () => {
+    if (!startupRendered) {
+      startupRendered = true  // set BEFORE the call
+      try {
+        await bridge.createStartUpPageContainer(new CreateStartUpPageContainer(config))
+      } catch (err) {
+        startupRendered = false  // allow retry on failure
+        throw err
+      }
+    } else {
+      await bridge.rebuildPageContainer(new RebuildPageContainer(config))
+    }
+  })
+}
+```
+
+## Atomic Multi-Container Updates
+
+When updating multiple text containers (e.g., a reader + status bar), update them in a single enqueued batch. If you enqueue them separately, the render queue drops intermediate pending renders, causing desync.
+
+```typescript
+async function updateTextBatch(
+  bridge: EvenAppBridge,
+  updates: Array<{ containerID: number; containerName: string; content: string }>,
+) {
+  await enqueueRender(async () => {
+    for (const u of updates) {
+      await bridge.textContainerUpgrade(new TextContainerUpgrade({
+        containerID: u.containerID,
+        containerName: u.containerName,
+        contentOffset: 0,
+        contentLength: 2000,
+        content: u.content,
+      }))
+    }
+  })
+}
+```
+
 ## Common UI Patterns
 
 ### Fake buttons

--- a/skills/handle-input/SKILL.md
+++ b/skills/handle-input/SKILL.md
@@ -59,8 +59,8 @@ Events route differently depending on the **active container type** (the one wit
 | 4 | FOREGROUND_ENTER_EVENT | App comes to foreground |
 | 5 | FOREGROUND_EXIT_EVENT | App goes to background |
 | 6 | ABNORMAL_EXIT_EVENT | Unexpected disconnect |
-| — | IMU_DATA_REPORT | IMU data sample |
-| — | SYSTEM_EXIT_EVENT | System exit |
+| 7 | SYSTEM_EXIT_EVENT | System-level exit |
+| 8 | IMU_DATA_REPORT | IMU data sample |
 
 ## Event Models
 
@@ -146,11 +146,40 @@ const unsubscribe = bridge.onEvenHubEvent(event => {
 
 G2 (temple touchpads) and R1 (ring touchpads) share the same gesture set. To distinguish between them, check `eventSource` in `Sys_ItemEvent`. The `EventSourceType` value indicates whether input came from the left arm, right arm, or ring accessory.
 
+## Exit Mechanism — Mandatory
+
+Every app MUST provide a way to exit via glasses/ring interaction. Use the system-level exit confirmation — do NOT build custom exit dialogs.
+
+**Recommended pattern — double-tap calls system popup:**
+
+```typescript
+function handleEvent(event: EvenHubEvent) {
+  const type = event.sysEvent?.eventType ?? event.textEvent?.eventType ?? event.listEvent?.eventType
+  const eventType = type ?? 0
+
+  if (eventType === 3) { // DOUBLE_CLICK_EVENT
+    // Save state, disable IMU, clean up
+    flushState()
+    bridge.imuControl(false).catch(() => {})
+    unsubscribe()
+    bridge.shutDownPageContainer(1)  // 1 = system confirmation popup
+    return
+  }
+}
+```
+
+**`shutDownPageContainer` modes:**
+- `shutDownPageContainer(0)` — immediate exit, no confirmation (use sparingly)
+- `shutDownPageContainer(1)` — system-level "Exit?" popup on the glasses (recommended)
+
+The system popup is the canonical pattern — it matches Even's native apps. Do not draw your own confirmation dialog; it adds complexity and the SDK provides this for free.
+
 ## Important Notes
 
 - **Clicks on text containers route to `sysEvent`**, not `textEvent`. Only scroll gestures fire `textEvent`. This is the most common source of event-handling bugs.
-- **Cleanup**: `bridge.onEvenHubEvent()` returns an unsubscribe function. Always call it on component teardown.
+- **Cleanup**: `bridge.onEvenHubEvent()` returns an unsubscribe function. Always call it on component teardown — including on exit events (ABNORMAL_EXIT, SYSTEM_EXIT).
 - **One event listener per page**: Only the container with `isEventCapture: 1` receives input events. If multiple containers have `isEventCapture: 1`, the SDK rejects the page with a validation error.
+- **Handle ALL lifecycle events**: FOREGROUND_ENTER (4) to re-render, FOREGROUND_EXIT (5) to save state, ABNORMAL_EXIT (6) and SYSTEM_EXIT (7) to clean up resources (disable IMU/audio, unsubscribe, flush state).
 
 ## Task
 


### PR DESCRIPTION
## Summary

基于 G2 Reader（电子书阅读器）和 Chrono（计时器）两个应用从 0 到 1 的真实开发调试经验，补充了 6 项 plugin 中缺失的关键知识。这些都是在真机测试中反复踩坑后验证的模式——不是理论推导，是实打实的 bug fix。

## 变更详情

### 1. `glasses-ui` — 渲染队列 + startupRendered + 原子更新

**问题**: 并发 bridge 调用会导致眼镜崩溃重启；BLE 单次调用 hang 住会冻结整个渲染管线 ~30 秒；SDK `createStartUpPageContainer` 返回值是字符串 `'success'` 而非数字 `0`，按文档检查 `result === 0` 会导致每次渲染都重复调用 startup，刷爆 bridge。

**新增内容**:
- 渲染队列模式（序列化 + 4s BLE 超时保护）
- `startupRendered` 正确追踪方式（调用前设 true，catch 中回滚）
- 多容器原子更新（`updateTextBatch`）防止阅读器+状态栏 desync

### 2. `handle-input` — 退出机制 + 生命周期

**问题**: 开发者自己画退出确认对话框，增加不必要的复杂度。SDK 已提供系统级弹窗。Plugin 提到了 `shutDownPageContainer` 但没有强调推荐模式。`SYSTEM_EXIT_EVENT` 值（7）在枚举表中缺失。

**新增内容**:
- `shutDownPageContainer(1)` 作为标准退出模式的完整代码示例
- `SYSTEM_EXIT_EVENT = 7` 补全到枚举表
- 生命周期事件处理要求（FOREGROUND_EXIT 保存状态、ABNORMAL_EXIT/SYSTEM_EXIT 清理资源）

### 3. `device-features` — IndexedDB 警告 + 防抖持久化

**问题**: Flutter WebView 中 IndexedDB 在 app 重启后数据丢失——元数据（SDK localStorage）还在但内容（IndexedDB）没了。每次翻页都调 `setLocalStorage` 会刷爆 bridge。

**新增内容**:
- IndexedDB 不可靠的明确警告 + SDK localStorage 分块存储大数据的代码示例
- 防抖持久化模式（500ms debounce + exit 时 flush）

### 4. `build-and-deploy` — CORS 全面文档

**问题**: 开发者以为 `app.json` 的 `whitelist` 能绕过 CORS——不能。WebView 是真正的浏览器引擎，完整 CORS 执行。免费 CORS 代理（corsproxy.io、allorigins.win、api.codetabs.com）全部不稳定——403、超时、间歇性故障。

**新增内容**:
- app.json whitelist ≠ CORS 绕过的明确说明
- 三种场景的解决方案表
- Vite 开发代理配置
- 免费 CORS 代理不可靠的警告

### 5. `design-guidelines` — Even 设计令牌内联

**问题**: Plugin 链接到 even-toolkit 但没有内联具体的颜色值、字体规格、间距。开发者需要去翻源码才能知道 `--color-text` 是什么。

**新增内容**:
- 完整颜色令牌表（light + dark）
- 字体规格表（FK Grotesk Neue、8 个样式级别、负 letter-spacing）
- 间距令牌表
- 品牌规则（#FEF991 仅限 accent、#3CFA44 仅限眼镜端）

## 验证方式

这些模式均在以下应用中验证通过：
- **G2 Reader v1.3.0** — 电子书阅读器（Gutenberg 搜索 + 下载 + 阅读）
- **Chrono v1.3.0** — 计时器（Timer / Stopwatch / Pomodoro）

## Test Plan

- [ ] 检查每个修改的 SKILL.md 语法和格式正确
- [ ] 确认新增代码示例可以编译（TypeScript 语法正确）
- [ ] 确认没有修改不相关的 skill 文件
- [ ] 运行 `/harness glasses-ui` 验证 glasses-ui skill 输出质量

🤖 Generated with [Claude Code](https://claude.com/claude-code)