### PR TITLE
实战验证的最佳实践补充（#1 收窄重做）

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/niceven/evenhub-skills"
+    "url": "https://github.com/even-realities/evenhub-skills"
   }
 }

--- a/skills/build-and-deploy/SKILL.md
+++ b/skills/build-and-deploy/SKILL.md
@@ -137,6 +137,48 @@ Do NOT use a key-value map format:
 
 ---
 
+## CORS in the WebView
+
+The Even App runs your plugin inside a real browser engine (Chromium on Android, WKWebView on iOS). **Full CORS enforcement applies.** The `app.json` network whitelist is an Even-level permission check — it does NOT bypass CORS. You need BOTH:
+
+1. The domain whitelisted in `app.json` `permissions.network.whitelist`, AND
+2. The remote API to respond with the correct CORS headers (`Access-Control-Allow-Origin`, etc.)
+
+If the API you're calling doesn't send CORS headers, `fetch()` will fail with a network error even though the domain is whitelisted.
+
+| Scenario | Fix |
+|---|---|
+| API has CORS headers | Just whitelist the domain in `app.json` — it works |
+| API has no CORS headers | Use your own backend, a Cloudflare Worker proxy (free tier), or find a CORS-enabled mirror |
+| Dev server (localhost) is blocked by CORS | Add a Vite proxy in `vite.config.ts` — see below |
+
+### Vite dev proxy
+
+Use a Vite proxy to avoid CORS during local development:
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://api.example.com',
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/api/, ''),
+      },
+    },
+  },
+})
+```
+
+This proxy only works in dev. For the production `.ehpk`, the WebView makes requests directly — your API must have CORS headers, or you must route through your own proxy.
+
+### Free CORS proxy services are unreliable
+
+Public proxies like `corsproxy.io`, `allorigins.win`, and `api.codetabs.com` go down, return 403s, or timeout without warning. If your app depends on a third-party API without CORS, deploy your own Cloudflare Worker (free tier, ~5 min setup) or find a mirror that serves CORS headers natively.
+
+---
+
 ## evenhub pack Options
 
 ```

--- a/skills/design-guidelines/SKILL.md
+++ b/skills/design-guidelines/SKILL.md
@@ -72,6 +72,43 @@ Full supported glyph tables: https://github.com/nickustinov/even-g2-notes
 - **No concurrent image sends** — wait for each to complete
 - Use simple/flat colors; glasses have limited memory
 
+## Phone-Side App UI (Flutter WebView host)
+
+The glasses render monochrome green on black, but the Flutter WebView that hosts your plugin on the phone has its own visual identity. Match the Even app design system when building phone-side config / settings / library screens so your plugin feels native inside Even Hub.
+
+### Color tokens
+
+| Token | Light | Dark | Use |
+|---|---|---|---|
+| `--color-text` | `#232323` (TC-1st) | `#FFFFFF` | Primary text |
+| `--color-text-dim` | `#7B7B7B` (TC-2nd) | `#8A8A8A` | Secondary text, timestamps, captions |
+| `--color-bg` | `#FFFFFF` (BC-1st) | `#111111` | Page background |
+| `--color-surface` | `#EEEEEE` (BC-3rd) | `#1A1A1A` | Card / row background |
+| `--color-input-bg` | `rgba(35,35,35,0.08)` | `rgba(255,255,255,0.08)` | Search bar, input fields |
+| `--color-accent` | `#FEF991` | `#FEF991` | Brand accent (sparingly — buttons, highlights) |
+| `--color-text-on-accent` | `#FFFFFF` | `#FFFFFF` | Text on accent backgrounds |
+
+**Brand rules:**
+- `#FEF991` is Even brand yellow — use only for accent (buttons, highlights), never as a page background
+- `#3CFA44` is glasses-display green — use ONLY on the G2 display, NEVER in phone-side UI
+
+### Typography
+
+Primary: **FK Grotesk Neue** (negative letter-spacing for a tight, editorial feel). Fallback: **Source Han Sans** for CJK, system sans for everything else.
+
+| Style | Size | Weight | Letter-spacing |
+|---|---|---|---|
+| Display | 34 px | 700 | -0.02em |
+| Title | 24 px | 600 | -0.02em |
+| Subtitle | 18 px | 500 | -0.01em |
+| Body | 16 px | 400 | -0.01em |
+| Caption | 13 px | 400 | 0 |
+| Label | 11 px | 500 | 0.04em (uppercase) |
+
+### Spacing
+
+Use a 4/8 px grid: `4 8 12 16 24 32 48 64`. Card padding: 16. Section spacing: 24–32. Screen edge padding: 20.
+
 ## Figma Design Guidelines
 
 Official design guidelines covering layout principles, component patterns, interaction models, and visual standards:

--- a/skills/device-features/SKILL.md
+++ b/skills/device-features/SKILL.md
@@ -119,6 +119,30 @@ Persist data to the Even Realities App (survives app restarts):
 - `await bridge.setLocalStorage(key, value)` — stores a string value; returns `boolean` indicating success
 - `await bridge.getLocalStorage(key)` — retrieves a stored string; returns an empty string if the key does not exist
 
+### SDK localStorage is the only reliable persistence
+
+The Even App WebView is a Flutter WebView. **Browser IndexedDB and browser `localStorage` do NOT reliably persist across app restarts** in this environment — data saved there can be lost when the user closes and reopens the app.
+
+Use `bridge.setLocalStorage` / `bridge.getLocalStorage` for all user state: settings, progress, bookmarks, preferences, cached content. For large content (e.g. ebook text), chunk it across multiple keys:
+
+```typescript
+const CHUNK_SIZE = 50_000  // chars per key
+const PREFIX = 'myapp.content_'
+
+async function saveContent(bridge: EvenAppBridge, id: string, text: string) {
+  const chunks = Math.ceil(text.length / CHUNK_SIZE)
+  await bridge.setLocalStorage(`${PREFIX}${id}_n`, String(chunks))
+  for (let i = 0; i < chunks; i++) {
+    await bridge.setLocalStorage(
+      `${PREFIX}${id}_${i}`,
+      text.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE),
+    )
+  }
+}
+```
+
+See `glasses-ui` → Best Practices for debouncing and serializing bridge writes.
+
 ---
 
 ## Cleanup on Exit

--- a/skills/glasses-ui/SKILL.md
+++ b/skills/glasses-ui/SKILL.md
@@ -227,6 +227,12 @@ shutDownPageContainer(type: number): Promise<boolean>
 - **Always match `containerID` and `containerName` exactly** when calling `textContainerUpgrade` — mismatches silently fail
 - **Do not call `updateImageRawData` concurrently** — queue updates and await each before sending the next
 - **Pre-paginate long text** at ~400–500 character boundaries and use `rebuildPageContainer` on scroll events
+- **Image frames cost ~0.5s each over BLE** — no compression, no delta encoding; design turn-based and avoid loops that assume multi-FPS
+- **Text updates are much faster than image updates** — use text for anything that needs to feel instant; let image containers catch up on their own
+- **Serialize all bridge calls, not just images** — `await` each before starting the next; concurrent render + storage calls can crash the connection
+- **Add a per-call timeout to BLE calls** — a single flaky hop can hang ~30s; wrap calls in `Promise.race` with a few-second cap
+- **Debounce persistent state writes** — `setLocalStorage` shares the same BLE link; debounce on tick/page-turn and flush on exit
+- **Call `createStartUpPageContainer` exactly once** — every subsequent render uses `rebuildPageContainer` or a `*Upgrade` call
 
 ## Common UI Patterns
 

--- a/skills/glasses-ui/SKILL.md
+++ b/skills/glasses-ui/SKILL.md
@@ -227,7 +227,7 @@ shutDownPageContainer(type: number): Promise<boolean>
 - **Always match `containerID` and `containerName` exactly** when calling `textContainerUpgrade` — mismatches silently fail
 - **Do not call `updateImageRawData` concurrently** — queue updates and await each before sending the next
 - **Pre-paginate long text** at ~400–500 character boundaries and use `rebuildPageContainer` on scroll events
-- **Image frames cost ~0.5s each over BLE** — no compression, no delta encoding; design turn-based and avoid loops that assume multi-FPS
+- **Image frames cost ~0.5s to ~2s each over BLE** — no compression, no delta encoding; design turn-based and avoid loops that assume multi-FPS
 - **Text updates are much faster than image updates** — use text for anything that needs to feel instant; let image containers catch up on their own
 - **Serialize all bridge calls, not just images** — `await` each before starting the next; concurrent render + storage calls can crash the connection
 - **Add a per-call timeout to BLE calls** — a single flaky hop can hang ~30s; wrap calls in `Promise.race` with a few-second cap

--- a/skills/handle-input/SKILL.md
+++ b/skills/handle-input/SKILL.md
@@ -47,6 +47,7 @@ Events route differently depending on the **active container type** (the one wit
 | Foreground enter | `event.sysEvent` | `4` (FOREGROUND_ENTER_EVENT) |
 | Foreground exit | `event.sysEvent` | `5` (FOREGROUND_EXIT_EVENT) |
 | Abnormal exit | `event.sysEvent` | `6` (ABNORMAL_EXIT_EVENT) |
+| System exit | `event.sysEvent` | `7` (SYSTEM_EXIT_EVENT) |
 
 ## OsEventTypeList enum values
 
@@ -59,8 +60,8 @@ Events route differently depending on the **active container type** (the one wit
 | 4 | FOREGROUND_ENTER_EVENT | App comes to foreground |
 | 5 | FOREGROUND_EXIT_EVENT | App goes to background |
 | 6 | ABNORMAL_EXIT_EVENT | Unexpected disconnect |
-| — | IMU_DATA_REPORT | IMU data sample |
-| — | SYSTEM_EXIT_EVENT | System exit |
+| 7 | SYSTEM_EXIT_EVENT | System-level exit (e.g. user confirmed exit dialog) |
+| 8 | IMU_DATA_REPORT | IMU data sample |
 
 ## Event Models
 
@@ -145,6 +146,39 @@ const unsubscribe = bridge.onEvenHubEvent(event => {
 ## G2 vs R1 Distinction
 
 G2 (temple touchpads) and R1 (ring touchpads) share the same gesture set. To distinguish between them, check `eventSource` in `Sys_ItemEvent`. The `EventSourceType` value indicates whether input came from the left arm, right arm, or ring accessory.
+
+## Exit Mechanism
+
+Every app should provide a way to exit via glasses/ring interaction. Use the SDK's built-in system exit dialog rather than building your own confirmation UI.
+
+**Canonical pattern — double-tap to show system exit dialog:**
+
+```typescript
+if (eventType === 3) { // DOUBLE_CLICK_EVENT
+  // Show the system exit dialog. Don't clean up resources here —
+  // the user can still cancel. If they confirm, the SDK fires
+  // SYSTEM_EXIT_EVENT (7) and you clean up in that handler.
+  bridge.shutDownPageContainer(1)
+  return
+}
+```
+
+**`shutDownPageContainer` modes:**
+- `shutDownPageContainer(0)` — immediate exit, no confirmation
+- `shutDownPageContainer(1)` — system exit confirmation dialog (recommended)
+
+Do not `unsubscribe()` / stop hardware / flush state *before* calling `shutDownPageContainer(1)`. If you do and the user taps cancel, the app is still on screen but no longer listening for events. Clean up in the `ABNORMAL_EXIT_EVENT` / `SYSTEM_EXIT_EVENT` handlers instead.
+
+## Lifecycle Events
+
+Handle all four lifecycle events for a clean app:
+
+| Event | When to use it |
+|-------|----------------|
+| `FOREGROUND_ENTER_EVENT` (4) | Re-render current state, resume timers/IMU |
+| `FOREGROUND_EXIT_EVENT` (5) | Flush pending state to `setLocalStorage`, pause timers |
+| `ABNORMAL_EXIT_EVENT` (6) | Stop hardware (`imuControl(false)`, `audioControl(false)`), unsubscribe, flush state |
+| `SYSTEM_EXIT_EVENT` (7) | Same cleanup as ABNORMAL_EXIT — user confirmed exit from the system dialog |
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary

这是对 #1 的 follow-up，根据 @Frefreak 的 review 意见做了大幅收窄。主要变化：

- **不再包含 opinionated 的实现代码**（render queue、atomic multi-container 等）
- **去掉了无法验证的说法**（createStartUpPageContainer 返回 `'success'` 字符串）
- **风格对齐**：新增内容沿用每个 skill 现有 Best Practices 区块的简短 bullet 风格

## 变更详情

### 1. `glasses-ui` — 在 Best Practices 末尾追加 6 条 bullet

与现有的 5 条 bullet 风格一致，不加单独章节。补充的是 BLE 链路约束下的通用原则：

- 图像帧 ~0.5s/帧 → 设计要 turn-based
- 文本更新比图像更新快得多
- 序列化所有 bridge 调用（不只是图像）
- 每个 BLE 调用加超时
- 持久化写入要 debounce
- \`createStartUpPageContainer\` 只调用一次

### 2. \`handle-input\` — 退出机制 + 生命周期

- 补全 \`SYSTEM_EXIT_EVENT = 7\` 到两个表
- 新增 Exit Mechanism 章节，强调 \`shutDownPageContainer(1)\` 前**不要**清理资源（用户可能取消对话框）
- 新增 Lifecycle Events 表格覆盖 4 个生命周期事件

### 3. \`device-features\` — IndexedDB 警告

- 明确说明 Flutter WebView 中 IndexedDB 不可靠
- 提供大内容分块存储示例
- debounce 相关指向 glasses-ui

### 4. \`build-and-deploy\` — CORS 完整文档

- app.json whitelist ≠ CORS 绕过
- Vite 开发代理配置示例
- 免费 CORS 代理不稳定的警告（corsproxy.io、allorigins.win 等）

### 5. \`design-guidelines\` — 手机端 App UI 章节

- 颜色令牌表（light + dark，含 \`--color-text\`、\`--color-bg\`、\`--color-surface\`、\`--color-input-bg\`、\`--color-accent\`）
- FK Grotesk Neue 字体规格表（6 级 type scale + negative letter-spacing）
- 间距令牌（4/8px grid）
- 品牌色使用规则

### 6. \`package.json\`

修正 repository URL：\`niceven/evenhub-skills\` → \`even-realities/evenhub-skills\`

## 验证方式

所有补充内容均在以下生产应用中验证：
- **G2 Reader v2.1.1** — 电子书阅读器
- **Chrono v2.1.1** — 计时器 / 秒表 / Pomodoro

## 对 #1 review 的回应

| Review 意见 | 处理方式 |
|---|---|
| \`'success'\` 返回类型没见过，有 repro 吗 | ✅ 去掉该说法，不再出现 |
| render queue 代码太 opinionated | ✅ 去掉代码块，改为一条 bullet |
| 多次 textContainerUpgrade 会失效？有 PoC 吗 | ✅ 去掉 Atomic Multi-Container 章节 |
| debounce 感觉是 common sense | ✅ 不再单独写成章节/代码块，收敛为一条 bullet |

#1 将关闭。

## Test plan

- [ ] 验证每个 SKILL.md 语法和渲染正确
- [ ] 确认 bullet 风格与现有内容一致
- [ ] 运行 \`/harness glasses-ui\` 等验证 skill 输出质量
- [ ] 确认 package.json URL 正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)