### PR TITLE
Add /template skill → degit curated starters from LesenmiaoYu/evenhub-templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Everything EvenHub
 
-Everything EvenHub is a Claude Code skill set for Even Realities G2 smart glasses app development. It provides 11 AI-assisted skills covering the full development lifecycle — from project scaffolding to UI composition, input handling, device features, simulation testing, font measurement, and SDK/CLI reference lookups.
+Everything EvenHub is a Claude Code skill set for Even Realities G2 smart glasses app development. It provides 12 AI-assisted skills covering the full development lifecycle — from project scaffolding to UI composition, input handling, device features, simulation testing, font measurement, and SDK/CLI reference lookups.
 
 ## Prerequisites
 
@@ -27,8 +27,14 @@ The skills will be available after installation. To update later:
 After installation, try these in any Claude Code session:
 
 ```bash
-# Scaffold a new G2 app
+# Scaffold a new G2 app from scratch (blank Vite base)
 /quickstart my-weather-app
+
+# Or scaffold from a curated starter template — pick the one closest to what you're building
+/template my-reader --text-heavy
+/template --asr my-transcription-app
+/template --image photo-frame
+/template --minimal hello-glasses
 
 # Build and package for distribution
 /build-and-deploy
@@ -69,7 +75,8 @@ During development, use these skills to implement features:
 
 | Tier | Skill | Description |
 |------|-------|-------------|
-| Tier 1 — One-Click | `quickstart` | Scaffold a new G2 app from scratch |
+| Tier 1 — One-Click | `quickstart` | Scaffold a blank G2 app from scratch (Vite + TS + SDK) |
+| Tier 1 — One-Click | `template` | Scaffold from a curated starter (`minimal`, `asr`, `image`, `text-heavy`) via degit |
 | Tier 1 — One-Click | `build-and-deploy` | Package and publish app to Even Hub |
 | Tier 2 — Core Development | `glasses-ui` | Build glasses display UI with containers, text, images, and lists |
 | Tier 2 — Core Development | `handle-input` | Handle touchpad gestures, ring input, and lifecycle events |

--- a/skills/glasses-ui/SKILL.md
+++ b/skills/glasses-ui/SKILL.md
@@ -126,6 +126,8 @@ Image containers do not support `isEventCapture`. Use a text container as the ev
 - Accepts: `number[] | Uint8Array | ArrayBuffer | base64` string
 - Color depth: 4-bit greyscale (values 0–15 per pixel)
 
+**Preprocessing is optional.** You don't need to pre-grayscale or dither before sending — the SDK converts common formats internally and only returns `imageToGray4Failed` if it can't. Line art, icons, and QR codes usually render fine raw; photos and gradients benefit from a client-side contrast boost + Floyd–Steinberg dither pass on a 16-shade display, but try the naive path first.
+
 **Critical behavior:**
 - Image containers are **placeholders on creation** — they display nothing until `updateImageRawData` is called
 - **Always call `updateImageRawData` after creating an image container** to display content

--- a/skills/template/SKILL.md
+++ b/skills/template/SKILL.md
@@ -14,7 +14,7 @@ Scaffold a new Even Hub G2 project by cloning one of the starter templates from 
 | `minimal` | Bare Vite + TS + SDK scaffold. Shows "Hello from G2!" on the glasses. |
 | `asr` | Mic → STT pipeline with companion UI, double-tap exit. STT provider is a blank stub — user picks their own. |
 | `image` | `ImageContainerProperty` demo with test-pattern bitmap, tap-to-redraw, event-capture layer pattern. |
-| `text-heavy` | Long-form reader: pre-paginated, flicker-free page turns via `textContainerUpgrade`, tap/swipe navigation. Pair with [`@evenrealities/pretext`](https://www.npmjs.com/package/@evenrealities/pretext) for accurate font measurement when char-count pagination isn't precise enough. |
+| `text-heavy` | Long-form reader: pixel-accurate pagination via [`@evenrealities/pretext`](https://www.npmjs.com/package/@evenrealities/pretext) (measures each paragraph at the glyph widths LVGL uses on G2), flicker-free page turns via `textContainerUpgrade`, tap/swipe navigation. |
 
 ## How to interpret `$ARGUMENTS`
 
@@ -66,7 +66,7 @@ cd <project-dir> && npm install
   - Open `src/asr/stt.ts` and implement `startSttStream()` for their chosen provider (Deepgram, AssemblyAI, Whisper, Soniox, self-hosted — their call).
   - Add a `network` permission to `app.json` with the provider's hosts in the `whitelist` array once they pick one. `evenhub pack` rejects an empty whitelist, which is why the template ships without it.
 - **`image`** → Tell the user they can either keep the test-pattern generator or swap `makeTestPattern` for `loadImageBytes` in `src/image/renderer.ts` once they have a real asset. Remind them preprocessing is optional (the SDK handles greyscale conversion).
-- **`text-heavy`** → Tell the user to replace `src/sample.ts` with their actual content and tune `PAGE_CHAR_BUDGET` in `src/main.ts` if their text is denser or sparser than the default. For production-quality pagination that respects real glyph widths, install `@evenrealities/pretext` and swap the char-budget pagination for `pretext`'s layout helpers.
+- **`text-heavy`** → Tell the user to replace `src/sample.ts` with their actual content. Pagination is driven by the container's pixel box via `@evenrealities/pretext` — if they resize the body, edit `BODY_W` / `BODY_H` / `BODY_PAD` at the top of `src/main.ts` and pagination re-fits automatically (no char-budget to tune).
 - **`minimal`** → No follow-up.
 
 ### 6. Print next steps

--- a/skills/template/SKILL.md
+++ b/skills/template/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: template
+description: Scaffold an Even Hub G2 app from a curated starter template (minimal, asr, image, text-heavy). Use when the user wants a ready-made starting point with working wiring, not a blank Vite project. Flag-driven — pick the template with --asr, --image, --text-heavy, or --minimal.
+allowed-tools: [Read, Grep, Glob, Bash, Write, Edit]
+argument-hint: [project name] [--minimal | --asr | --image | --text-heavy]
+---
+
+Scaffold a new Even Hub G2 project by cloning one of the starter templates from [`LesenmiaoYu/evenhub-templates`](https://github.com/LesenmiaoYu/evenhub-templates) via `degit`. Unlike `/quickstart` (which bootstraps a blank Vite app from scratch), this skill drops the user into a template that already has the wiring they asked for — mic pipeline, image container, paginated reader, etc.
+
+## Available templates
+
+| Template | What's inside |
+|---|---|
+| `minimal` | Bare Vite + TS + SDK scaffold. Shows "Hello from G2!" on the glasses. |
+| `asr` | Mic → STT pipeline with companion UI, double-tap exit. STT provider is a blank stub — user picks their own. |
+| `image` | `ImageContainerProperty` demo with test-pattern bitmap, tap-to-redraw, event-capture layer pattern. |
+| `text-heavy` | Long-form reader: pre-paginated, flicker-free page turns via `textContainerUpgrade`, tap/swipe navigation. |
+
+## How to parse `$ARGUMENTS`
+
+Arguments can arrive in any order and in many spellings. Be lenient.
+
+1. **Split `$ARGUMENTS` on whitespace.** Separate tokens starting with `--` (or `-`) from non-flag tokens.
+2. **Normalize flag tokens:** lowercase them, strip leading dashes, strip a leading `with-` or `with` prefix, strip internal dashes and underscores. Examples that must all map to the same thing:
+   - `--asr`, `--with-asr`, `--withasr`, `--ASR`, `-asr`, `--with_asr` → `asr`
+   - `--image`, `--with-image`, `--withimage`, `--img` → `image`
+   - `--text-heavy`, `--textheavy`, `--with-text-heavy`, `--text`, `--reader` → `text-heavy`
+   - `--minimal`, `--min`, `--blank`, `--base`, `--empty` → `minimal`
+3. **Fuzzy-match the normalized token against the available templates.** Accept an exact match, a prefix match, or any template whose name contains the token. If multiple templates match, prefer the shorter one (`image` beats `image-something`). If nothing matches confidently, default to `minimal` and tell the user which template you picked and why.
+4. **The remaining non-flag tokens form the project name.** Join them with spaces, then slugify: lowercase, replace whitespace/underscores with `-`, strip anything that isn't `[a-z0-9-]`. If the user provided no non-flag tokens, default to `my-<template>-app` (e.g. `my-asr-app`).
+5. **Derive `package_id` slug** from the project name by removing hyphens (e.g. `my-asr-app` → `myasrapp`). The template already ships an `app.json` with a placeholder `package_id` — edit it to `com.example.<slug>` after degit completes.
+
+If the user passes no flags at all (just a project name or nothing), default to `minimal` and mention the other options so they can rerun with the flag they actually want.
+
+## Steps
+
+### 1. Parse arguments
+
+Apply the parsing rules above. Print a one-line summary before running: `Scaffolding <template> template → <project-dir>/`. If you defaulted to `minimal` because the flag was ambiguous or missing, say so explicitly.
+
+### 2. Fetch the template via degit
+
+```bash
+npx --yes degit LesenmiaoYu/evenhub-templates/<template> <project-dir>
+```
+
+This pulls just the chosen template directory (no git history). Use `--yes` so npx doesn't prompt on first run.
+
+### 3. Rename the project
+
+Edit these files to replace placeholders with the user's project name:
+
+- `package.json` — change `"name"` from the template default (e.g. `"evenhub-asr"`) to the slugified project name.
+- `app.json` — change `"package_id"` to `com.example.<slug>` and `"name"` to a human-readable form of the project name.
+
+### 4. Install dependencies
+
+```bash
+cd <project-dir> && npm install
+```
+
+### 5. Template-specific follow-ups
+
+- **`asr`** → Tell the user:
+  - Copy `.env.example` to `.env.local` and paste their STT provider's API key into `VITE_STT_API_KEY`.
+  - Open `src/asr/stt.ts` and implement `startSttStream()` for their chosen provider (Deepgram, AssemblyAI, Whisper, Soniox, self-hosted — their call).
+  - Add a `network` permission to `app.json` with the provider's hosts in the `whitelist` array once they pick one. `evenhub pack` rejects an empty whitelist, which is why the template ships without it.
+- **`image`** → Tell the user they can either keep the test-pattern generator or swap `makeTestPattern` for `loadImageBytes` in `src/image/renderer.ts` once they have a real asset. Remind them preprocessing is optional (the SDK handles greyscale conversion).
+- **`text-heavy`** → Tell the user to replace `src/sample.ts` with their actual content and tune `PAGE_CHAR_BUDGET` in `src/main.ts` if their text is denser or sparser than the default.
+- **`minimal`** → No follow-up.
+
+### 6. Print next steps
+
+```
+cd <project-dir>
+npm run dev                                    # start Vite dev server
+npm run simulate                               # desktop simulator
+npx evenhub qr --url http://<your-ip>:5173     # QR for real glasses
+npx evenhub pack                               # build .ehpk for distribution
+```
+
+Point the user at the template's own `README.md` for deeper specifics (it's the authoritative doc).
+
+## Design notes
+
+- **Templates live in a separate public repo**, not inside this skill suite. That's intentional: the templates evolve independently (new examples, SDK version bumps) without re-releasing the skill. The skill is a thin degit wrapper.
+- **Fuzzy flag matching, not strict.** Users will type `--withasr`, `--asr`, `--with-ASR` — all of these should land on the same template. Normalize aggressively before matching.
+- **Do not edit the templates from this skill.** If a template needs a fix, open a PR against [`LesenmiaoYu/evenhub-templates`](https://github.com/LesenmiaoYu/evenhub-templates) instead.
+- **Prefer `/quickstart` for a truly blank slate.** `/template --minimal` is close but still ships with an `index.html` + zoom-lock CSS + our preferred `tsconfig`; `/quickstart` runs `npm create vite@latest` and wires the SDK in fresh.
+
+## Hardware quick reference
+
+| Property | Value |
+|---|---|
+| Display | 576 x 288 px, 4-bit greyscale (16 shades of green) |
+| Microphone | PCM s16le @ 16 kHz mono |
+| Camera | None |
+| Speaker | None |
+| Input | Touchpad on the temple, optional R1 ring |
+
+## Task
+
+Parse `$ARGUMENTS`, pick the template, scaffold it, apply template-specific follow-ups, and print next steps: $ARGUMENTS

--- a/skills/template/SKILL.md
+++ b/skills/template/SKILL.md
@@ -14,11 +14,11 @@ Scaffold a new Even Hub G2 project by cloning one of the starter templates from 
 | `minimal` | Bare Vite + TS + SDK scaffold. Shows "Hello from G2!" on the glasses. |
 | `asr` | Mic → STT pipeline with companion UI, double-tap exit. STT provider is a blank stub — user picks their own. |
 | `image` | `ImageContainerProperty` demo with test-pattern bitmap, tap-to-redraw, event-capture layer pattern. |
-| `text-heavy` | Long-form reader: pre-paginated, flicker-free page turns via `textContainerUpgrade`, tap/swipe navigation. |
+| `text-heavy` | Long-form reader: pre-paginated, flicker-free page turns via `textContainerUpgrade`, tap/swipe navigation. Pair with [`@evenrealities/pretext`](https://www.npmjs.com/package/@evenrealities/pretext) for accurate font measurement when char-count pagination isn't precise enough. |
 
-## How to parse `$ARGUMENTS`
+## How to interpret `$ARGUMENTS`
 
-Arguments can arrive in any order and in many spellings. Be lenient.
+Arguments can arrive in any order and in many spellings. Be lenient — this is loose pattern matching, not formal parsing.
 
 1. **Split `$ARGUMENTS` on whitespace.** Separate tokens starting with `--` (or `-`) from non-flag tokens.
 2. **Normalize flag tokens:** lowercase them, strip leading dashes, strip a leading `with-` or `with` prefix, strip internal dashes and underscores. Examples that must all map to the same thing:
@@ -34,9 +34,9 @@ If the user passes no flags at all (just a project name or nothing), default to 
 
 ## Steps
 
-### 1. Parse arguments
+### 1. Interpret arguments
 
-Apply the parsing rules above. Print a one-line summary before running: `Scaffolding <template> template → <project-dir>/`. If you defaulted to `minimal` because the flag was ambiguous or missing, say so explicitly.
+Apply the interpretation rules above. Print a one-line summary before running: `Scaffolding <template> template → <project-dir>/`. If you defaulted to `minimal` because the flag was ambiguous or missing, say so explicitly.
 
 ### 2. Fetch the template via degit
 
@@ -66,7 +66,7 @@ cd <project-dir> && npm install
   - Open `src/asr/stt.ts` and implement `startSttStream()` for their chosen provider (Deepgram, AssemblyAI, Whisper, Soniox, self-hosted — their call).
   - Add a `network` permission to `app.json` with the provider's hosts in the `whitelist` array once they pick one. `evenhub pack` rejects an empty whitelist, which is why the template ships without it.
 - **`image`** → Tell the user they can either keep the test-pattern generator or swap `makeTestPattern` for `loadImageBytes` in `src/image/renderer.ts` once they have a real asset. Remind them preprocessing is optional (the SDK handles greyscale conversion).
-- **`text-heavy`** → Tell the user to replace `src/sample.ts` with their actual content and tune `PAGE_CHAR_BUDGET` in `src/main.ts` if their text is denser or sparser than the default.
+- **`text-heavy`** → Tell the user to replace `src/sample.ts` with their actual content and tune `PAGE_CHAR_BUDGET` in `src/main.ts` if their text is denser or sparser than the default. For production-quality pagination that respects real glyph widths, install `@evenrealities/pretext` and swap the char-budget pagination for `pretext`'s layout helpers.
 - **`minimal`** → No follow-up.
 
 ### 6. Print next steps
@@ -75,8 +75,8 @@ cd <project-dir> && npm install
 cd <project-dir>
 npm run dev                                    # start Vite dev server
 npm run simulate                               # desktop simulator
-npx evenhub qr --url http://<your-ip>:5173     # QR for real glasses
-npx evenhub pack                               # build .ehpk for distribution
+npx @evenrealities/evenhub-cli qr --url http://<your-ip>:5173    # QR for real glasses
+npx @evenrealities/evenhub-cli pack                              # build .ehpk for distribution
 ```
 
 Point the user at the template's own `README.md` for deeper specifics (it's the authoritative doc).
@@ -100,4 +100,4 @@ Point the user at the template's own `README.md` for deeper specifics (it's the 
 
 ## Task
 
-Parse `$ARGUMENTS`, pick the template, scaffold it, apply template-specific follow-ups, and print next steps: $ARGUMENTS
+Interpret `$ARGUMENTS`, pick the template, scaffold it, apply template-specific follow-ups, and print next steps: $ARGUMENTS


### PR DESCRIPTION
## Summary

- Adds new `/template` skill that scaffolds G2 apps from a curated starter repo via `degit` — `--minimal`, `--asr`, `--image`, `--text-heavy`. Templates live in a separate public repo ([LesenmiaoYu/evenhub-templates](https://github.com/LesenmiaoYu/evenhub-templates)) so they can evolve without re-releasing the skill suite.
- Flag parsing is intentionally lenient — `--asr`, `--with-asr`, `--withasr`, `--ASR` all route to the same template. Normalize + fuzzy-match before picking.
- `/quickstart` stays as the blank-slate option; `/template` is for developers who want working wiring (mic pipeline, image container pattern, paginated reader) in place.
- `glasses-ui/SKILL.md`: adds a "preprocessing is optional" note under `ImageContainerProperty`. The SDK handles greyscale conversion internally; line art / icons / QR codes render fine raw, dithering is only useful for photos and gradients.
- README: skill count 11 → 12, new `/template` invocation examples.

## The templates themselves

All four smoke-tested end-to-end (`npm install` → `tsc --noEmit` → `vite build` pass):

| Template | What's inside |
|---|---|
| `minimal` | Bare Vite + TS + SDK scaffold, "Hello from G2!", double-tap quit wiring. |
| `asr` | Mic → STT pipeline with companion WebView mirror. `src/asr/stt.ts` is a blank stub — user picks their own provider. |
| `image` | `ImageContainerProperty` demo with test-pattern bitmap, tap-to-redraw, event-capture layer pattern. |
| `text-heavy` | Long-form reader, pre-paginated, flicker-free page turns via `textContainerUpgrade`. |

All templates ship with zoom-locked WebView (`viewport` meta + `touch-action: manipulation` + `-webkit-text-size-adjust: 100%` + `overscroll-behavior: none`), brand-compliant companion UI (ER Design Library 3.0 dark surfaces #232323 / #2E2E2E / #3E3E3E + OS green #3CFA44), and double-tap → `shutDownPageContainer(1)` quit dialog wiring.

## Test plan

- [ ] `/template --minimal hello` scaffolds a runnable app
- [ ] `/template --asr transcriber` scaffolds with STT stub intact
- [ ] `/template --image photo-frame` scaffolds with ImageContainerProperty working
- [ ] `/template --text-heavy reader` scaffolds with pagination + page turns
- [ ] Fuzzy-matches `--withasr`, `--with-ASR`, `--asr`, `-asr` all hit the `asr` template
- [ ] No-flag invocation defaults to `minimal` and tells the user why

🤖 Generated with [Claude Code](https://claude.com/claude-code)